### PR TITLE
Remove FlowFindRefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,6 @@ Turns automatic checks on save on or off.
 
 Display the type of the variable under the cursor.
 
-#### `FlowFindRefs <arg>`
-
-Find the number of references to `<arg>` within the project.
-
 ## Configuration
 
 #### `g:flow#autoclose`

--- a/plugin/flow.vim
+++ b/plugin/flow.vim
@@ -91,10 +91,6 @@ function! flow#typecheck()
   call <SID>FlowClientCall('2> /dev/null')
 endfunction
 
-function! flow#find_refs(fn)
-  call <SID>FlowClientCall('--find-refs '.a:fn.'| sed "s/[0-9]* total results//"')
-endfunction
-
 " Get the Flow type at the current cursor position.
 function! flow#get_type()
   let pos = fnameescape(expand('%')).' '.line('.').' '.col('.')
@@ -119,7 +115,6 @@ endfunction
 command! FlowToggle call flow#toggle()
 command! FlowMake   call flow#typecheck()
 command! FlowType   call flow#get_type()
-command! -nargs=1 FlowFindRefs call flow#find_refs(<q-args>)
 
 au BufWritePost *.js,*.jsx if g:flow#enable | call flow#typecheck() | endif
 


### PR DESCRIPTION
The functionality isn't supported in flow currently, and is probably an accidental copy of similar functionality in vim-hack.