### PR TITLE
JumpToDef: No jump marks

### DIFF
--- a/plugin/flow.vim
+++ b/plugin/flow.vim
@@ -118,8 +118,10 @@ function! flow#jump_to_def()
   let file = parts[0]
   let row = parts[1]
   let col = split(parts[2], ",")[0]
-  execute 'edit' file
-  call cursor(row, col)
+  if filereadable(file)
+    execute 'edit' file
+    call cursor(row, col)
+  end
 endfunction
 
 

--- a/plugin/flow.vim
+++ b/plugin/flow.vim
@@ -11,7 +11,6 @@ let g:loaded_flow = 1
 " - errjmp:     Jump to errors after typechecking; default off.
 " - qfsize:     Let the plugin control the quickfix window size.
 " - flowpath:   Path to the flow executable - default is flow in path
-" - flowmark:   Mark key flow will set to - default is "F"
 if !exists("g:flow#enable")
   let g:flow#enable = 1
 endif
@@ -26,9 +25,6 @@ if !exists("g:flow#qfsize")
 endif
 if !exists("g:flow#flowpath")
   let g:flow#flowpath = "flow"
-endif
-if !exists("g:flow#flowmark")
-  let g:flow#flowmark = "F"
 endif
 
 " Require the flow executable.
@@ -122,7 +118,6 @@ function! flow#jump_to_def()
   let file = parts[0]
   let row = parts[1]
   let col = split(parts[2], ",")[0]
-  execute 'mark' g:flow#flowmark
   execute 'edit' file
   call cursor(row, col)
 endfunction


### PR DESCRIPTION
Based on follow-up convo at https://github.com/flowtype/vim-flow/pull/27#issuecomment-231058400.

Also added a quick check to ensure a file exists before opening a file and doing the cursor movement.