### PR TITLE
Run the ftplugin every time

### DIFF
--- a/after/ftplugin/javascript.vim
+++ b/after/ftplugin/javascript.vim
@@ -1,10 +1,5 @@
 " Vim filetype plugin
 
-if exists("b:did_ftplugin_flow")
-  finish
-endif
-let b:did_ftplugin_flow = 1
-
 " Require the flow executable.
 if !executable('flow')
   finish


### PR DESCRIPTION
If another plugin re-sets the filetype, we might need to overwrite the new omnifunc value to make sure it's still set to flow. This happens with vim-jsx, which sets the filetype to `javascript.jsx`

Context: https://github.com/mxw/vim-jsx/issues/103