### PR TITLE
Update repo URL in NeoBundle sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A vim plugin for [Flow][flow].
 Add this to your `~/.vimrc`
 
 ```VimL
-  NeoBundleLazy 'facebook/vim-flow', {
+  NeoBundleLazy 'flowtype/vim-flow', {
             \ 'autoload': {
             \     'filetypes': 'javascript'
             \ }}
@@ -32,7 +32,7 @@ Add this to your `~/.vimrc`
 #### With [Flow][flow] build step, using [flow-bin][flowbin]
 
 ```VimL
-  NeoBundleLazy 'facebook/vim-flow', {
+  NeoBundleLazy 'flowtype/vim-flow', {
             \ 'autoload': {
             \     'filetypes': 'javascript'
             \ },


### PR DESCRIPTION
related to #23.

I confirmed NeoBundle works fine with both of the repository names, but it is confusing to leave the old one.