### PR TITLE
Adding configurable timeout variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ By default `omnifunc` will be set to provide omni completion. To disable it
 let g:flow#omnifunc = 0
 ```
 
+#### `g:flow#timeout`
+
+By default `timeout` will be set to 2 seconds. If you are working on a larger
+codebase, you may want to increase this to avoid errors when Flow initializes.
+
+```VimL
+let g:flow#timeout = 4
+```
+
 #### `g:flow#qfsize`
 
 Leave this as default to let the plugin decide on the quickfix window size.

--- a/plugin/flow.vim
+++ b/plugin/flow.vim
@@ -26,6 +26,9 @@ endif
 if !exists("g:flow#flowpath")
   let g:flow#flowpath = "flow"
 endif
+if !exists("g:flow#timeout")
+  let g:flow#timeout = 2
+endif
 
 " Require the flow executable.
 if !executable(g:flow#flowpath)
@@ -73,7 +76,7 @@ endfunction
 function! flow#typecheck()
   " Flow current outputs errors to stderr and gets fancy with single character
   " files
-  let flow_result = <SID>FlowClientCall('--timeout 2 --retry-if-init false'.expand('%:p'), '2> /dev/null')
+  let flow_result = <SID>FlowClientCall('--timeout '.g:flow#timeout.' --retry-if-init false'.expand('%:p'), '2> /dev/null')
   let old_fmt = &errorformat
   let &errorformat = s:flow_errorformat
 


### PR DESCRIPTION
This will help with larger codebases that require a longer flow initialization time. Was running into this issue on our Discord codebase.