### PR TITLE
Return empty matches if autocomplete not found

### DIFF
--- a/autoload/flowcomplete.vim
+++ b/autoload/flowcomplete.vim
@@ -37,6 +37,11 @@ function! flowcomplete#Complete(findstart, base)
   let command = g:flow#flowpath.' autocomplete '.expand('%:p')
   let result = system(command, buffer)
 
+  if result =~ '^Error: not enough type information to autocomplete' ||
+    \ result =~ '^Could not find file or directory'
+    return []
+  endif
+
   let matches = []
 
   " Parse the flow output.


### PR DESCRIPTION
Return no matches when autocomplete doesn't have type information. 

Before:
![screenshot 2016-08-31 at 09 59 18](https://cloud.githubusercontent.com/assets/5181/18138482/b3a5988c-6f61-11e6-89b3-230ae526218e.png)

After:
![screenshot 2016-08-31 at 09 59 59](https://cloud.githubusercontent.com/assets/5181/18138487/b687534c-6f61-11e6-8623-3ce0303bcf4d.png)

