### PR TITLE
Do not parse the result of `get-def` if no definition was found

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Turns automatic checks on save on or off.
 
 Display the type of the variable under the cursor.
 
+#### `FlowJumpToDef` 
+
+Jump to the definition of the variable under the cursor.
+
 ## Configuration
 
 #### `g:flow#autoclose`

--- a/plugin/flow.vim
+++ b/plugin/flow.vim
@@ -120,6 +120,12 @@ function! flow#jump_to_def()
   " Output format is:
   "   File: "/path/to/file", line 1, characters 1-11
 
+  " Flow returns a single line-feed if no result
+  if strlen(flow_result) == 1
+    echo 'No definition found'
+    return
+  endif
+
   let parts = split(flow_result, ",")
 
   " File: "/path/to/file" => /path/to/file


### PR DESCRIPTION
Also added `FlowJumpToDef` to the readme.