### PR TITLE
Use flowpath when loading flowcomplete

### DIFF
--- a/after/ftplugin/javascript.vim
+++ b/after/ftplugin/javascript.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 
 " Require the flow executable.
-if !executable('flow')
+if !executable(g:flow#flowpath)
   finish
 endif
 


### PR DESCRIPTION
This should ensure that completion works when a separate `flowpath` is specified.