### PR TITLE
Updated to handle paths with spaces.

### DIFF
--- a/autoload/flowcomplete.vim
+++ b/autoload/flowcomplete.vim
@@ -34,7 +34,7 @@ function! flowcomplete#Complete(findstart, base)
 
   " Pass the buffer to flow.
   let buffer = join(lines, "\n")
-  let command = g:flow#flowpath.' autocomplete '.expand('%:p')
+  let command = g:flow#flowpath.' autocomplete "'.expand('%:p').'"'
   let result = system(command, buffer)
 
   if result =~ '^Error: not enough type information to autocomplete' ||

--- a/plugin/flow.vim
+++ b/plugin/flow.vim
@@ -76,7 +76,7 @@ endfunction
 function! flow#typecheck()
   " Flow current outputs errors to stderr and gets fancy with single character
   " files
-  let flow_result = <SID>FlowClientCall('--timeout '.g:flow#timeout.' --retry-if-init false'.expand('%:p'), '2> /dev/null')
+  let flow_result = <SID>FlowClientCall('--timeout '.g:flow#timeout.' --retry-if-init false "'.expand('%:p').'"', '2> /dev/null')
   let old_fmt = &errorformat
   let &errorformat = s:flow_errorformat
 

--- a/plugin/flow.vim
+++ b/plugin/flow.vim
@@ -152,7 +152,7 @@ endfunction
 
 " Open importers of current file in quickfix window
 function! flow#get_importers()
-  let flow_result = <SID>FlowClientCall('get-importers '.expand('%').' --strip-root', '')
+  let flow_result = <SID>FlowClientCall('get-importers "'.expand('%').'" --strip-root', '')
   let importers = split(flow_result, '\n')[1:1000]
 
   let l:flow_errorformat = '%f'


### PR DESCRIPTION
Autocomplete and get-importers were throwing errors for me when there's a space within the file path. This fix wraps the file path with double quotes and fixes the issue for me. Tested on Arch Linux.