### PR TITLE
Fix file delimiter under Windows when using git bash

### DIFF
--- a/plugin/flow.vim
+++ b/plugin/flow.vim
@@ -133,7 +133,7 @@ function! flow#jump_to_def()
   endif
 
   " File: "/path/to/file" => /path/to/file
-  let file = substitute(substitute(parts[0], '"', '', 'g'), 'File ', '', '')
+  let file = substitute( substitute(substitute(parts[0], '"', '', 'g'), 'File ', '', ''), '\', '/', 'g')
 
   " line 1 => 1
   let row = split(parts[1], " ")[1]


### PR DESCRIPTION
Windows uses '\' for delimiters, so flow reports 'path/to/file' as 'path\to\file' (which becomes 'pathtofile') when using vim from git bash or other simulated unix env.

Not sure what is the case with gvim.
