### PR TITLE
Clarify documentation for autoclose option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Jump to the definition of the variable under the cursor.
 
 #### `g:flow#autoclose`
 
-If this is set to `1`, the |quickfix| window opened when the plugin finds an error
-will close automatically.
+If this is set to `1`, the quickfix window will not be opened when there are
+no errors, and will be automatically closed when previous errors are cleared.
 
 Default is `0`.
 

--- a/doc/vim-flow.txt
+++ b/doc/vim-flow.txt
@@ -11,8 +11,8 @@ VARIABLES                                                   *vim-flow-variables*
 
 g:flow#autoclose                                              *g:flow#autoclose*
 
-If this is set to 1, the |quickfix| window opened when the plugin finds an error
-will close automatically.
+If this is set to 1, the |quickfix| window will not be opened when there are
+no errors, and will be automatically closed when previous errors are cleared.
 
 Default is 0.
 

--- a/plugin/flow.vim
+++ b/plugin/flow.vim
@@ -7,7 +7,7 @@ let g:loaded_flow = 1
 
 " Configuration switches:
 " - enable:     Typechecking is done on :w.
-" - autoclose:  Quickfix window closes automatically.
+" - autoclose:  Quickfix window closes automatically when there are no errors.
 " - errjmp:     Jump to errors after typechecking; default off.
 " - qfsize:     Let the plugin control the quickfix window size.
 " - flowpath:   Path to the flow executable - default is flow in path


### PR DESCRIPTION
It doesn't "close the quickfix window automatically". I'm not even sure what that is supposed to mean. It does not open the quick window when there are no errors, and closes the existing window if there previously were but now aren't. I think.

I went months thinking there was no way to have this plugin not open the quickfix window when there are no errors. Hopefully this will save other people some time.

I also removed the meaningless vim help format pipes around `quickfix` from the README.