### PR TITLE
Add showquickfix config

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ let g:flow#timeout = 4
 
 Leave this as default to let the plugin decide on the quickfix window size.
 
+#### `g:flow#showquickfix`
+
+By default, results are shown in a quickfix window. Setting this to 0 will
+stop the window from being shown. This is useful if you want to use
+vim-flow for the omnicomplete functionality, but are already using
+something like [ale](https://github.com/w0rp/ale).
+
+```VimL
+let g:flow#showquickfix = 0
+```
+
 [gflowenable]: https://github.com/flowtype/vim-flow#gflowenable
 [flow]: https://github.com/facebook/flow
 [flowbin]: https://github.com/sindresorhus/flow-bin

--- a/plugin/flow.vim
+++ b/plugin/flow.vim
@@ -6,11 +6,12 @@ endif
 let g:loaded_flow = 1
 
 " Configuration switches:
-" - enable:     Typechecking is done on :w.
-" - autoclose:  Quickfix window closes automatically.
-" - errjmp:     Jump to errors after typechecking; default off.
-" - qfsize:     Let the plugin control the quickfix window size.
-" - flowpath:   Path to the flow executable - default is flow in path
+" - enable:       Typechecking is done on :w.
+" - autoclose:    Quickfix window closes automatically.
+" - errjmp:       Jump to errors after typechecking; default off.
+" - qfsize:       Let the plugin control the quickfix window size.
+" - flowpath:     Path to the flow executable - default is flow in path
+" - showquickfix  Show the quickfix window
 if !exists("g:flow#enable")
   let g:flow#enable = 1
 endif
@@ -28,6 +29,9 @@ if !exists("g:flow#flowpath")
 endif
 if !exists("g:flow#timeout")
   let g:flow#timeout = 2
+endif
+if !exists("g:flow#showquickfix")
+  let g:flow#showquickfix = 1
 endif
 
 " Require the flow executable.
@@ -86,10 +90,12 @@ function! flow#typecheck()
     cgetexpr flow_result
   endif
 
-  if g:flow#autoclose
-    botright cwindow
-  else
-    botright copen
+  if g:flow#showquickfix
+    if g:flow#autoclose
+      botright cwindow
+    else
+      botright copen
+    endif
   endif
   let &errorformat = old_fmt
 endfunction


### PR DESCRIPTION
Not sure if you guys want to add this or not, but I did it for myself, so I figured I'd put it here just in case you do want it.

I'm using [ale](https://github.com/w0rp/ale) for running eslint and flow async, which I find to be nicer than the quickfix window on save, but I still need vim-flow for the omnicomplete functionality. This just creates the `g:flow#showquickfix` config that allows the user to set vim-flow to not open the quickfix window.