### PR TITLE
Fix(ftplugin) allow user to define flow binary

### DIFF
--- a/after/ftplugin/javascript.vim
+++ b/after/ftplugin/javascript.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 
 " Require the flow executable.
-if !executable('flow')
+if !executable(g:flow#flowpath)
   finish
 endif
 


### PR DESCRIPTION
Looks like this just got overlooked when adding the `flowpath` setting.