### PR TITLE
Pass --quite to FlowClientCall() in flow#jump_to_def()

### DIFF
--- a/plugin/flow.vim
+++ b/plugin/flow.vim
@@ -126,7 +126,7 @@ function! flow#jump_to_def()
   let pos = line('.').' '.col('.')
   let path = ' --path '.fnameescape(expand('%'))
   let stdin = join(getline(1,'$'), "\n")
-  let flow_result = <SID>FlowClientCall('get-def '.pos.path, '', stdin)
+  let flow_result = <SID>FlowClientCall('get-def --quiet '.pos.path, '', stdin)
   " Output format is:
   "   File: "/path/to/file", line 1, characters 1-11
 


### PR DESCRIPTION
:FlowJumpToDef currently doesn't work without this flag (tested with
flow v0.61.0 nvim v0.2.0).  It's probably flow server's fault to output
server information in the presence of `--from vim` but it doesn't hurt
to have this flag set.