### PR TITLE
Add --quiet flag to FlowClientCall's

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,22 @@ Triggers a type check for the current file.
 
 Turns automatic checks on save on or off.
 
-#### `FlowType` 
+#### `FlowType`, `FlowTypeExpandAliases`
 
 Display the type of the variable under the cursor.
 
-#### `FlowJumpToDef` 
+The latter form (`:FlowTypeExpandAliases`) will inline any aliased types into
+the output, so for example a type like this:
+
+```js
+type Foo = number;
+type Bar = {foo: Foo};
+```
+
+Asking for the type of `Bar` will print `{foo: number}`. Notice how the `Foo`
+type alias in `Bar`'s definition was expanded to just `number`.
+
+#### `FlowJumpToDef`
 
 Jump to the definition of the variable under the cursor.
 

--- a/plugin/flow.vim
+++ b/plugin/flow.vim
@@ -101,10 +101,18 @@ function! flow#typecheck()
 endfunction
 
 " Get the Flow type at the current cursor position.
-function! flow#get_type()
+function! flow#get_type(expand)
   let pos = line('.').' '.col('.')
   let path = ' --path '.fnameescape(expand('%'))
-  let cmd = g:flow#flowpath.' type-at-pos --quiet '.pos.path
+
+  let l:args = join([
+    \ 'type-at-pos',
+    \ '--quiet',
+    \ a:expand ? '--expand-type-aliases' : '',
+    \ pos.path,
+    \ ], ' ')
+
+  let cmd = g:flow#flowpath.' '.l:args
   let stdin = join(getline(1,'$'), "\n")
 
   let output = 'FlowType: '.system(cmd, stdin)
@@ -188,11 +196,12 @@ endfunction
 
 
 " Commands and auto-typecheck.
-command! FlowToggle       call flow#toggle()
-command! FlowMake         call flow#typecheck()
-command! FlowType         call flow#get_type()
-command! FlowJumpToDef    call flow#jump_to_def()
-command! FlowGetImporters call flow#get_importers()
+command! FlowToggle            call flow#toggle()
+command! FlowMake              call flow#typecheck()
+command! FlowType              call flow#get_type(0)
+command! FlowTypeExpandAliases call flow#get_type(1)
+command! FlowJumpToDef         call flow#jump_to_def()
+command! FlowGetImporters      call flow#get_importers()
 
 au BufWritePost *.js,*.jsx if g:flow#enable | call flow#typecheck() | endif
 

--- a/plugin/flow.vim
+++ b/plugin/flow.vim
@@ -104,7 +104,7 @@ endfunction
 function! flow#get_type()
   let pos = line('.').' '.col('.')
   let path = ' --path '.fnameescape(expand('%'))
-  let cmd = g:flow#flowpath.' type-at-pos '.pos.path
+  let cmd = g:flow#flowpath.' type-at-pos --quiet '.pos.path
   let stdin = join(getline(1,'$'), "\n")
 
   let output = 'FlowType: '.system(cmd, stdin)
@@ -165,7 +165,7 @@ endfunction
 
 " Open importers of current file in quickfix window
 function! flow#get_importers()
-  let flow_result = <SID>FlowClientCall('get-importers "'.expand('%').'" --strip-root', '')
+  let flow_result = <SID>FlowClientCall('get-importers --quiet "'.expand('%').'" --strip-root', '')
   let importers = split(flow_result, '\n')[1:1000]
 
   let l:flow_errorformat = '%f'


### PR DESCRIPTION
In the most recent PR, we forgot to add `--quiet` in a few places.