### PR TITLE
Add syntax highlighting for flow comment types

### DIFF
--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -1,0 +1,33 @@
+if exists("b:current_syntax")
+  let s:current_syntax=b:current_syntax
+  unlet b:current_syntax
+endif
+
+" classify flow flag
+syntax match flowAnnotationFlag "@flow" contained
+  \ containedin=jsComment
+
+" classify keywords, that indicate flow comment include
+syntax match flowTypeCommentKeyword "::"
+syntax match flowTypeCommentKeyword "flow-include"
+
+" classify flow comment include and type annotation regions
+" - \/\*                    - (= "/*") begin of a js block comment
+" - \%(::\?\|flow-include\) - check for keywords to begin type comments
+" - \@=                     - check but don't include in the matched
+"                             group
+" - \*\/                    - (= "*/") end of a js block comment
+syntax region flowTypeComment matchgroup=jsComment
+  \ transparent fold keepend
+  \ start="\/\*\%(::\?\|flow-include\)\@=" end="\*\/"
+  \ contains=jsFlowArgumentDef,jsFlowClassGroup,jsFlowType,
+  \          jsFlowTypeStatement,flowTypeCommentKeyword
+  \ containedin=js.*Block,jsClassDefinition,jsFuncArgs
+
+" highlight the appropriate syntax elements accordingly
+highlight default link flowAnnotationFlag Special
+highlight default link flowTypeCommentKeyword Comment
+
+if exists("s:current_syntax")
+  let b:current_syntax=s:current_syntax
+endif


### PR DESCRIPTION
Hello, I made this PR to allow for "easier" readability of type definitions, when using the flotate/comment type syntax.

I'm up for discussions, whether this is ok or needs expanding of any sort.

Changes:
- Match comment type include and annotation region.
- Allow FlowType syntax inside of these regions.
- Highlight single colon to represent special meaning (kept verbosely in
  type annotation).

Note:
- When saving the file the first time after opening it will temporarily revert the syntax back to the original one. I suppose this is because [vim-javascript][https://github.com/pangloss/vim-javascript] has a `BufWritePost` autocommand, that loads the flow syntax items. Reloading the file with `:e` fixes this.
- When adding a new line after starting the flow type comment, the comment will be continued. This is because of the `formatoptions` (the `cpo` portions of them, to be specific), that I wasn't able to store/restore when adding a new line.
- When adding a new line after starting the flow type comment, the indentation will be off by one shiftwidth. I don't really understand, where this is coming from.